### PR TITLE
Add gh action to build and publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Build and publish artifact
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Grant execute permission for build script
+        run: chmod +x ./build.sh
+      - name: Build whispertron
+        run: ./build.sh
+      - name: Locate built app
+        id: find_app
+        run: |
+          APP_PATH=$(find "$HOME/Library/Developer/Xcode/DerivedData" -type d -name "whispertron.app" | head -n1)
+          echo "app_path=$APP_PATH" >> $GITHUB_OUTPUT
+      - name: Package build artifact
+        run: |
+          APP_PATH="${{ steps.find_app.outputs.app_path }}"
+          APP_DIR=$(dirname "$APP_PATH")
+          APP_NAME=$(basename "$APP_PATH")
+          cd "$APP_DIR"
+          zip -r whispertron.zip "$APP_NAME"
+          mv whispertron.zip "$GITHUB_WORKSPACE"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: whispertron.zip
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: 'Automated release of whispertron'

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,18 @@ Works on my:
 - M1 MacBook Air running MacOS 14.7.5 with XCode 16.1.
 - M4 Mac Mini running MacOS 15.1.1 with XCode 16.2.
 
+## Install
+
+### From Github
+
+Navigate to [releases](https://github.com/lynaghk/whispertron/releases/) and download the latest version.
+
+After downloading unzip it and double-click the `.app` file.
+
+Follow [this link](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/15.0/mac/15.0) to bypass the unknown developer warning.
+
+### From Source
+
 Run:
 
     ./build.sh


### PR DESCRIPTION
Create a new release in github and the app is built and uploaded to the release.

Example run and release:
https://github.com/Glyphack/whispertron/actions/runs/15472266955
https://github.com/Glyphack/whispertron/releases/tag/v1