### PR TITLE
Use curl instead of wget in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,14 +13,14 @@ FILE_PATH="whispertron/models/model.bin"
 if [ -f "$FILE_PATH" ]; then
     echo "Whisper model already downloaded."
 else
-    wget -O "$FILE_PATH" "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$MODEL.bin?download=true"
+    curl -L -o "$FILE_PATH" "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$MODEL.bin?download=true"
 fi
 
 FILE_PATH="whisper-v1.7.5-xcframework.zip"
 if [ -f "$FILE_PATH" ]; then
     echo "Whisper framework already downloaded."
 else
-    wget -O "$FILE_PATH" "https://github.com/ggml-org/whisper.cpp/releases/download/v1.7.5/whisper-v1.7.5-xcframework.zip"
+    curl -L -o "$FILE_PATH" "https://github.com/ggml-org/whisper.cpp/releases/download/v1.7.5/whisper-v1.7.5-xcframework.zip"
     unzip -d whisper_xcframework whisper-v1.7.5-xcframework.zip
 fi
 


### PR DESCRIPTION
Hi Kevin! In the spirit of making builds easier for users - I didn't have wget installed but did have curl, I figure thats the system default. I swapped these commands for curl and it installed correctly. Cheers!