### PR TITLE
Adds a Settings window for configuring the HotKey

### DIFF
--- a/stream-logs.sh
+++ b/stream-logs.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec log stream --predicate 'subsystem =="com.keminglabs.whispertron"' --debug

--- a/whispertron.xcodeproj/project.pbxproj
+++ b/whispertron.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		40F8347C2CA71E4E007DAA65 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8347B2CA71E4E007DAA65 /* main.swift */; };
 		40F834812CA724C8007DAA65 /* LibWhisper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F834802CA724C8007DAA65 /* LibWhisper.swift */; };
 		40F834832CA72889007DAA65 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F834822CA72889007DAA65 /* Recorder.swift */; };
+		5ED2BE442E0E3DAF00CEAECF /* HotkeyRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED2BE432E0E3DAF00CEAECF /* HotkeyRecorderView.swift */; };
 		D73B39372DC6622E00F3B948 /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D73B39362DC6622E00F3B948 /* whisper.xcframework */; };
 		D73B39382DC6622E00F3B948 /* whisper.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D73B39362DC6622E00F3B948 /* whisper.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D7ECCB332CB9429E00558635 /* models in Resources */ = {isa = PBXBuildFile; fileRef = D7ECCB322CB9429E00558635 /* models */; };
@@ -41,6 +42,7 @@
 		40F8347B2CA71E4E007DAA65 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		40F834802CA724C8007DAA65 /* LibWhisper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibWhisper.swift; sourceTree = "<group>"; };
 		40F834822CA72889007DAA65 /* Recorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recorder.swift; sourceTree = "<group>"; };
+		5ED2BE432E0E3DAF00CEAECF /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
 		D73B39362DC6622E00F3B948 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "whisper_xcframework/build-apple/whisper.xcframework"; sourceTree = "<group>"; };
 		D7C3BEB12CBACF0E00AEB012 /* whispertron.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = whispertron.entitlements; sourceTree = "<group>"; };
 		D7ECCB322CB9429E00558635 /* models */ = {isa = PBXFileReference; lastKnownFileType = folder; name = models; path = whispertron/models; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 		40F834692CA70F3A007DAA65 /* whispertron */ = {
 			isa = PBXGroup;
 			children = (
+				5ED2BE432E0E3DAF00CEAECF /* HotkeyRecorderView.swift */,
 				40F8347B2CA71E4E007DAA65 /* main.swift */,
 				40F8346A2CA70F3A007DAA65 /* AppDelegate.swift */,
 				40F8346C2CA70F3A007DAA65 /* ViewController.swift */,
@@ -178,6 +181,7 @@
 			files = (
 				40F834832CA72889007DAA65 /* Recorder.swift in Sources */,
 				40F834812CA724C8007DAA65 /* LibWhisper.swift in Sources */,
+				5ED2BE442E0E3DAF00CEAECF /* HotkeyRecorderView.swift in Sources */,
 				40F8346D2CA70F3A007DAA65 /* ViewController.swift in Sources */,
 				40F8346B2CA70F3A007DAA65 /* AppDelegate.swift in Sources */,
 				40F8347C2CA71E4E007DAA65 /* main.swift in Sources */,

--- a/whispertron/AppDelegate.swift
+++ b/whispertron/AppDelegate.swift
@@ -42,7 +42,7 @@ extension NSColor {
   }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, HotkeyRecorderDelegate {
   private var statusItem: NSStatusItem!
   private var whisperContext: WhisperContext?
   private var recorder: Recorder?
@@ -72,6 +72,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   private let MinimumTranscriptionDuration = 1.0
   private var audioLevelTimer: Timer?
   private var settingsWindow: NSWindow?
+  private var hotkeyRecorderView: HotkeyRecorderView?
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     
     DistributedNotificationCenter.default.addObserver(
@@ -284,7 +285,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   
   private func createSettingsWindow() {
     let windowWidth: CGFloat = 400
-    let windowHeight: CGFloat = 200
+    let windowHeight: CGFloat = 180
     
     settingsWindow = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
@@ -299,15 +300,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Create content view
     let contentView = NSView(frame: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight))
     
-    // Placeholder content
-    let titleLabel = NSTextField(labelWithString: "Hotkey Configuration")
-    titleLabel.font = NSFont.systemFont(ofSize: 16, weight: .medium)
-    titleLabel.frame = NSRect(x: 20, y: windowHeight - 60, width: 200, height: 24)
+    // Hotkey configuration section
+    let titleLabel = NSTextField(labelWithString: "Recording Hotkey:")
+    titleLabel.frame = NSRect(x: 20, y: windowHeight - 60, width: 120, height: 20)
     contentView.addSubview(titleLabel)
     
-    let descriptionLabel = NSTextField(labelWithString: "Current hotkey: ⌃⇧H")
-    descriptionLabel.frame = NSRect(x: 20, y: windowHeight - 90, width: 200, height: 20)
-    contentView.addSubview(descriptionLabel)
+    // Create and configure hotkey recorder view
+    hotkeyRecorderView = HotkeyRecorderView(frame: NSRect(x: 150, y: windowHeight - 62, width: 200, height: 24))
+    hotkeyRecorderView?.delegate = self
+    
+    // Set initial hotkey to match current app hotkey (Ctrl+Shift+H)
+    let currentHotkey = HotkeyRecorderView.Hotkey(keyCode: 4, modifiers: [.control, .shift])
+    hotkeyRecorderView?.setHotkey(currentHotkey)
+    
+    contentView.addSubview(hotkeyRecorderView!)
     
     // Close button
     let closeButton = NSButton(frame: NSRect(x: windowWidth - 80, y: 20, width: 60, height: 32))
@@ -370,5 +376,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Visual effect view automatically adapts to system appearance
     // visualEffectView.material = .hudWindow
     feedbackImageView?.contentTintColor = NSColor.isDarkMode ? darkFg : lightFg
+  }
+  
+  // MARK: - HotkeyRecorderDelegate
+  
+  func hotkeyRecorder(_ recorder: HotkeyRecorderView, didRecord hotkey: HotkeyRecorderView.Hotkey) {
+    logger.info("UI recorded hotkey: \(hotkey.displayString)")
+    // TODO: Update global hotkey and save to UserDefaults
+  }
+  
+  func hotkeyRecorderDidCancelRecording(_ recorder: HotkeyRecorderView) {
+    logger.info("Hotkey recording cancelled")
+  }
+  
+  func hotkeyRecorderDidStartRecording(_ recorder: HotkeyRecorderView) {
+    logger.info("Hotkey recording started - disabling global hotkey")
+    // TODO: Temporarily disable global hotkey during recording
+  }
+  
+  func hotkeyRecorderDidStopRecording(_ recorder: HotkeyRecorderView) {
+    logger.info("Hotkey recording stopped - re-enabling global hotkey")
+    // TODO: Re-enable global hotkey
   }
 }

--- a/whispertron/AppDelegate.swift
+++ b/whispertron/AppDelegate.swift
@@ -124,6 +124,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   // Translated from espanso's injectString function
   func insertStringAtCursor(_ string: String) {
+    logger.debug("insertStringAtCursor: \(string)")
+
     let udelay = UInt32(1000)
 
     DispatchQueue.main.async {

--- a/whispertron/AppDelegate.swift
+++ b/whispertron/AppDelegate.swift
@@ -71,6 +71,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   private var lastTranscript = ""
   private let MinimumTranscriptionDuration = 1.0
   private var audioLevelTimer: Timer?
+  private var settingsWindow: NSWindow?
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     
     DistributedNotificationCenter.default.addObserver(
@@ -254,6 +255,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     menu.addItem(recording)
 
     menu.addItem(NSMenuItem.separator())
+    
+    let settings = NSMenuItem(title: "Settings...", action: #selector(showSettings), keyEquivalent: ",")
+    menu.addItem(settings)
+
+    menu.addItem(NSMenuItem.separator())
 
     menu.addItem(
       NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
@@ -265,6 +271,57 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if let url = URL(string: "https://www.github.com/lynaghk/whispertron") {
       NSWorkspace.shared.open(url)
     }
+  }
+  
+  @objc func showSettings() {
+    if settingsWindow == nil {
+      createSettingsWindow()
+    }
+    
+    settingsWindow?.makeKeyAndOrderFront(nil)
+    NSApp.activate(ignoringOtherApps: true)
+  }
+  
+  private func createSettingsWindow() {
+    let windowWidth: CGFloat = 400
+    let windowHeight: CGFloat = 200
+    
+    settingsWindow = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight),
+      styleMask: [.titled, .closable],
+      backing: .buffered,
+      defer: false)
+    
+    settingsWindow?.title = "Whispertron Settings"
+    settingsWindow?.center()
+    settingsWindow?.isReleasedWhenClosed = false
+    
+    // Create content view
+    let contentView = NSView(frame: NSRect(x: 0, y: 0, width: windowWidth, height: windowHeight))
+    
+    // Placeholder content
+    let titleLabel = NSTextField(labelWithString: "Hotkey Configuration")
+    titleLabel.font = NSFont.systemFont(ofSize: 16, weight: .medium)
+    titleLabel.frame = NSRect(x: 20, y: windowHeight - 60, width: 200, height: 24)
+    contentView.addSubview(titleLabel)
+    
+    let descriptionLabel = NSTextField(labelWithString: "Current hotkey: ⌃⇧H")
+    descriptionLabel.frame = NSRect(x: 20, y: windowHeight - 90, width: 200, height: 20)
+    contentView.addSubview(descriptionLabel)
+    
+    // Close button
+    let closeButton = NSButton(frame: NSRect(x: windowWidth - 80, y: 20, width: 60, height: 32))
+    closeButton.title = "Close"
+    closeButton.bezelStyle = .rounded
+    closeButton.target = self
+    closeButton.action = #selector(closeSettings)
+    contentView.addSubview(closeButton)
+    
+    settingsWindow?.contentView = contentView
+  }
+  
+  @objc func closeSettings() {
+    settingsWindow?.orderOut(nil)
   }
 
   @objc func didTapStandby() {

--- a/whispertron/HotkeyRecorderView.swift
+++ b/whispertron/HotkeyRecorderView.swift
@@ -1,0 +1,270 @@
+import Cocoa
+import HotKey
+import os
+
+protocol HotkeyRecorderDelegate: AnyObject {
+    func hotkeyRecorder(_ recorder: HotkeyRecorderView, didRecord hotkey: HotkeyRecorderView.Hotkey)
+    func hotkeyRecorderDidCancelRecording(_ recorder: HotkeyRecorderView)
+    func hotkeyRecorderDidStartRecording(_ recorder: HotkeyRecorderView)
+    func hotkeyRecorderDidStopRecording(_ recorder: HotkeyRecorderView)
+}
+
+class HotkeyRecorderView: NSView {
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "HotkeyRecorderView")
+    
+    // MARK: - Hotkey Data Structure
+    struct Hotkey: Equatable {
+        let keyCode: UInt32
+        let modifiers: NSEvent.ModifierFlags
+        
+        var displayString: String {
+            var parts: [String] = []
+            
+            if modifiers.contains(.control) { parts.append("⌃") }
+            if modifiers.contains(.option) { parts.append("⌥") }
+            if modifiers.contains(.shift) { parts.append("⇧") }
+            if modifiers.contains(.command) { parts.append("⌘") }
+            
+            // Use HotKey library's built-in key description
+            if let key = Key(carbonKeyCode: keyCode) {
+                parts.append(key.description)
+            } else {
+                parts.append("Key\(keyCode)")
+            }
+            
+            return parts.joined()
+        }
+    }
+    
+    // MARK: - Properties
+    weak var delegate: HotkeyRecorderDelegate?
+    
+    private var currentHotkey: Hotkey? {
+        didSet {
+            updateDisplay()
+        }
+    }
+    
+    private var isRecording = false {
+        didSet {
+            updateRecordingState()
+        }
+    }
+    
+    // UI Elements
+    private let stackView = NSStackView()
+    private let hotkeyField = NSTextField()
+    private let recordButton = NSButton()
+    
+    // Event monitoring
+    private var localEventMonitor: Any?
+    private var globalEventMonitor: Any?
+    
+    // MARK: - Initialization
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    deinit {
+        // Clean up event monitors
+        if let monitor = localEventMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        if let monitor = globalEventMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        // Configure stack view
+        stackView.orientation = .horizontal
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+        
+        // Configure hotkey display field
+        hotkeyField.isEditable = false
+        hotkeyField.isBordered = true
+        hotkeyField.bezelStyle = .roundedBezel
+        hotkeyField.alignment = .center
+        hotkeyField.placeholderString = "No hotkey set"
+        hotkeyField.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Configure record button
+        recordButton.title = "Record"
+        recordButton.bezelStyle = .rounded
+        recordButton.target = self
+        recordButton.action = #selector(recordButtonClicked)
+        recordButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Add to stack view
+        stackView.addArrangedSubview(hotkeyField)
+        stackView.addArrangedSubview(recordButton)
+        
+        // Setup constraints
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            hotkeyField.widthAnchor.constraint(greaterThanOrEqualToConstant: 120),
+            recordButton.widthAnchor.constraint(equalToConstant: 80)
+        ])
+        
+        updateDisplay()
+    }
+    
+    // MARK: - Public API
+    func setHotkey(_ hotkey: Hotkey?) {
+        currentHotkey = hotkey
+    }
+    
+    func getHotkey() -> Hotkey? {
+        return currentHotkey
+    }
+    
+    // MARK: - Recording Control
+    @objc private func recordButtonClicked() {
+        if isRecording {
+            stopRecording()
+        } else {
+            startRecording()
+        }
+    }
+    
+    private func startRecording() {
+        guard !isRecording else { return }
+        
+        isRecording = true
+        logger.info("Starting hotkey recording")
+        
+        // Notify delegate to disable global hotkey
+        delegate?.hotkeyRecorderDidStartRecording(self)
+        
+        // Start local event monitoring (when app has focus)
+        localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
+            self?.logger.info("📥 Local event: \(event.type.rawValue), keyCode: \(event.keyCode)")
+            return self?.handleRecordingEvent(event)
+        }
+        
+        // Start global event monitoring (when app doesn't have focus)
+        globalEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
+            self?.logger.info("🌍 Global event: \(event.type.rawValue), keyCode: \(event.keyCode)")
+            _ = self?.handleRecordingEvent(event)
+        }
+        
+        logger.info("Event monitors active")
+        
+        // Make this view first responder to capture Escape key
+        window?.makeFirstResponder(self)
+    }
+    
+    private func stopRecording() {
+        guard isRecording else { return }
+        
+        isRecording = false
+        
+        if let monitor = localEventMonitor {
+            NSEvent.removeMonitor(monitor)
+            localEventMonitor = nil
+        }
+        
+        if let monitor = globalEventMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalEventMonitor = nil
+        }
+        
+        logger.info("Recording stopped")
+        delegate?.hotkeyRecorderDidStopRecording(self)
+        delegate?.hotkeyRecorderDidCancelRecording(self)
+    }
+    
+    // MARK: - Event Handling
+    private func handleRecordingEvent(_ event: NSEvent) -> NSEvent? {
+        guard isRecording else { return event }
+        
+        // Handle escape to cancel
+        if event.type == .keyDown && event.keyCode == 53 { // Escape key
+            stopRecording()
+            return nil // Block the event
+        }
+        
+        // Only process key down events with modifiers
+        guard event.type == .keyDown else { return nil }
+        
+        let keyCode = UInt32(event.keyCode)
+        let modifiers = event.modifierFlags.intersection([.control, .option, .shift, .command])
+        
+        // Require at least one modifier (to avoid capturing regular typing)
+        guard !modifiers.isEmpty else { return nil }
+        
+        // Don't allow just modifier keys alone
+        let isModifierKey = [55, 54, 59, 62, 58, 61, 56, 60, 63].contains(keyCode) // Cmd, Ctrl, Opt, Shift, Fn
+        guard !isModifierKey else { return nil }
+        
+        // Create and record the hotkey
+        let hotkey = Hotkey(keyCode: keyCode, modifiers: modifiers)
+        currentHotkey = hotkey
+        isRecording = false
+        
+        // Clean up monitors
+        if let monitor = localEventMonitor {
+            NSEvent.removeMonitor(monitor)
+            localEventMonitor = nil
+        }
+        if let monitor = globalEventMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalEventMonitor = nil
+        }
+        
+        // Notify delegate
+        logger.info("Recorded hotkey: \(hotkey.displayString)")
+        delegate?.hotkeyRecorderDidStopRecording(self)
+        delegate?.hotkeyRecorder(self, didRecord: hotkey)
+        
+        return nil // Block the event from being processed further
+    }
+    
+    // MARK: - UI Updates
+    private func updateDisplay() {
+        if let hotkey = currentHotkey {
+            hotkeyField.stringValue = hotkey.displayString
+        } else {
+            hotkeyField.stringValue = ""
+        }
+    }
+    
+    private func updateRecordingState() {
+        if isRecording {
+            recordButton.title = "Stop"
+            hotkeyField.stringValue = "Press hotkey..."
+            hotkeyField.textColor = .systemBlue
+        } else {
+            recordButton.title = "Record"
+            hotkeyField.textColor = .labelColor
+            updateDisplay()
+        }
+    }
+    
+    // MARK: - First Responder
+    override var acceptsFirstResponder: Bool {
+        return isRecording
+    }
+    
+    override func keyDown(with event: NSEvent) {
+        // Handle escape when we're first responder
+        if event.keyCode == 53 && isRecording { // Escape
+            stopRecording()
+        } else {
+            super.keyDown(with: event)
+        }
+    }
+}


### PR DESCRIPTION
These commits add a settings window, which shows the current recording hotkey and has a control for recording a different hotkey.

I believe it properly handles:
- suspending key recognition while recording a new key
- aborting recording with Esc
- persisting preferred key across app relaunches, to user defaults

How much have I tested this? Lightly. 

This was quite a journey to implement. I broke it into separate commits to make it easier to review. Full disclosure: there was a lot of vibing with Claude here, but I was working in a structured way and I do also know my way around Cocoa from work in past lives, so I'm reasonably confident this is correct.

The settings window could use some design love.